### PR TITLE
Expose nbia when only tcia_utils is imported

### DIFF
--- a/src/tcia_utils/__init__.py
+++ b/src/tcia_utils/__init__.py
@@ -1,0 +1,1 @@
+from . import nbia


### PR DESCRIPTION
Previously a consumer had to type ```from tcia_utils import nbia```; this change lets them access nbia through tcia_utils:

```
import tcia_utils
tcia_utils.nbia
```