### PR TITLE
Protect dataframe instantiation in downloadSeries

### DIFF
--- a/src/tcia_utils/nbia.py
+++ b/src/tcia_utils/nbia.py
@@ -589,11 +589,14 @@ def downloadSeries(series_data,
                    csv_filename = ""):
 
     endpoint = "getImage"
-    manifestDF=pd.DataFrame()
     seriesUID = ''
     success = 0
     failed = 0
     previous = 0
+
+    # Prep a dataframe for later
+    if format == "df" or format == "csv" or csv_filename != "":
+        manifestDF=pd.DataFrame()
 
     # get base URL
     base_url = setApiUrl(endpoint, api_url)


### PR DESCRIPTION
The pandas dependency is mostly guarded in this function as-is, except for the dataframe at the very top of the function. This PR puts it under the same if...s as other usages of pandas later on. 