### PR TITLE
Add IDC module to mirror nbia.py functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ dependencies = [
   "tqdm",
   "plotly",
   "IPython",
-  "idc-index"
+  "idc-index",
+  "pydicom",
+  "requests"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,7 @@ dependencies = [
   "IPython",
   "idc-index",
   "pydicom",
-  "requests",
-  "dicom2nifti",
-  "scipy"
+  "requests"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
   "IPython",
   "idc-index",
   "pydicom",
-  "requests"
+  "requests",
+  "dicom2nifti",
+  "scipy"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "pandas",
   "tqdm",
   "plotly",
-  "IPython"
+  "IPython",
+  "idc-index"
 ]
 
 [project.urls]

--- a/src/tcia_utils/__init__.py
+++ b/src/tcia_utils/__init__.py
@@ -3,3 +3,4 @@ from . import datacite
 from . import pathdb
 from . import utils
 from . import wordpress
+from . import idc

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -7,6 +7,7 @@ from IPython.display import HTML
 import os
 import plotly.express as px
 from tcia_utils.utils import format_disk_space
+import csv
 
 _log = logging.getLogger(__name__)
 
@@ -17,8 +18,8 @@ def get_client():
     global _client
     if _client is None:
         _client = IDCClient.client()
-    # Ensure index is registered in duckdb
-    _client.sql_query("SELECT 1 FROM index LIMIT 1")
+        # Ensure index is registered in duckdb upon initialization
+        _client.sql_query("SELECT 1 FROM index LIMIT 1")
     return _client
 
 # Mapping IDC columns to NBIA columns
@@ -188,6 +189,43 @@ def getManufacturer(collection: str = "", modality: str = "", bodyPart: str = ""
     df = client._duckdb_conn.execute(query, params).df()
     return format_output(df, format=format)
 
+def _processManifest(manifest_path: str) -> Union[List[str], str]:
+    """
+    Processes various manifest types and returns a list of UIDs or the path to an s5cmd manifest.
+    """
+    if manifest_path.endswith(".s5cmd"):
+        return manifest_path
+
+    try:
+        with open(manifest_path, 'r', newline='') as f:
+            first_line = f.readline().strip()
+            f.seek(0)
+
+            # Check for NBIA manifest
+            if first_line.startswith("downloadServerUrl="):
+                _log.info("Detected NBIA manifest.")
+                lines = f.readlines()
+                # Skip first 6 lines of metadata
+                uids = [line.strip() for line in lines[6:] if line.strip()]
+                return uids
+
+            # Check for CSV/TSV
+            if manifest_path.endswith((".csv", ".tsv")):
+                delimiter = "," if manifest_path.endswith(".csv") else "\t"
+                df = pd.read_csv(manifest_path, sep=delimiter)
+                for col in ["SeriesInstanceUID", "SeriesUID"]:
+                    if col in df.columns:
+                        _log.info(f"Detected {col} in CSV/TSV manifest.")
+                        return df[col].dropna().astype(str).tolist()
+
+            # Default: treat as one UID per line
+            _log.info("Treating manifest as one UID per line.")
+            return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+    except Exception as e:
+        _log.error(f"Error processing manifest {manifest_path}: {e}")
+        return []
+
 def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
                    number: int = 0,
                    path: str = "idcDownload",
@@ -196,26 +234,35 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
                    max_workers: int = 10):
     client = get_client()
     uids = []
+    s5cmd_manifest = None
+
     if input_type == "list":
         uids = series_data
     elif input_type == "df":
         uids = series_data['SeriesInstanceUID'].tolist()
     elif isinstance(series_data, str):
-        if series_data.endswith(".tcia") or series_data.endswith(".txt"):
-            with open(series_data, 'r') as f:
-                uids = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+        processed = _processManifest(series_data)
+        if isinstance(processed, str): # s5cmd path
+            s5cmd_manifest = processed
         else:
-            uids = [series_data]
+            uids = processed
     else:
         uids = [item['SeriesInstanceUID'] for item in series_data]
 
-    if number > 0:
+    if number > 0 and uids:
         uids = uids[:number]
 
-    _log.info(f"Downloading {len(uids)} series to {path}...")
-    client.download_dicom_series(seriesInstanceUID=uids, downloadDir=path)
+    if s5cmd_manifest:
+        _log.info(f"Downloading from s5cmd manifest {s5cmd_manifest} to {path}...")
+        client.download_from_manifest(manifestFile=s5cmd_manifest, downloadDir=path)
+    elif uids:
+        _log.info(f"Downloading {len(uids)} series to {path}...")
+        client.download_dicom_series(seriesInstanceUID=uids, downloadDir=path)
+    else:
+        _log.warning("No data found to download.")
+        return None
 
-    if format == "df":
+    if format == "df" and uids:
         return getSeriesList(uids)
     return None
 
@@ -231,6 +278,7 @@ def getSegRefSeries(uid: str):
     client = get_client()
     try:
         client.fetch_index('seg_index')
+        # Ensure it's registered
         client.sql_query("SELECT 1 FROM seg_index LIMIT 1")
         query = "SELECT segmented_SeriesInstanceUID FROM seg_index WHERE SeriesInstanceUID = ?"
         df = client._duckdb_conn.execute(query, [uid]).df()
@@ -297,8 +345,12 @@ def reportDataSummary(series_data, input_type="", report_type = "", format=""):
     elif input_type == "df":
         uids = series_data['SeriesInstanceUID'].tolist()
     elif isinstance(series_data, str):
-        with open(series_data, 'r') as f:
-            uids = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+        processed = _processManifest(series_data)
+        if isinstance(processed, list):
+            uids = processed
+        else:
+            _log.warning("Cannot generate report from s5cmd manifest path.")
+            return None
     else:
         uids = [item['SeriesInstanceUID'] for item in series_data]
 
@@ -381,8 +433,6 @@ def getSimpleSearch(
         client.sql_query("SELECT 1 FROM collections_index LIMIT 1")
         placeholders = ",".join(["?" for _ in species])
         where_clauses.append(f"collection_id IN (SELECT collection_id FROM collections_index WHERE Species IN ({placeholders}))")
-        # Species in collections_index are like 'Human', 'Mouse', etc.
-        # NBIA uses lowercase 'human'. Let's title case them for IDC.
         params.extend([s.title() for s in species])
 
     if modalities:
@@ -406,7 +456,6 @@ def getSimpleSearch(
         params.extend(patients)
 
     if fromDate:
-        # IDC StudyDate is YYYY-MM-DD
         isoFromDate = fromDate.replace("/", "-")
         where_clauses.append("StudyDate >= ?")
         params.append(isoFromDate)
@@ -420,7 +469,6 @@ def getSimpleSearch(
         query += " WHERE " + " AND ".join(where_clauses)
 
     if modalityAnded and modalities:
-        # Patients that have ALL the requested modalities
         placeholders = ",".join(["?" for _ in modalities])
         query += f" AND PatientID IN (SELECT PatientID FROM index WHERE Modality IN ({placeholders}) GROUP BY PatientID HAVING COUNT(DISTINCT Modality) = ?)"
         params.extend(modalities)

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -1,0 +1,351 @@
+import logging
+import pandas as pd
+from typing import Union, List, Optional
+from datetime import datetime
+from idc_index import IDCClient
+from IPython.display import HTML
+import os
+import concurrent.futures
+import plotly.express as px
+from tcia_utils.utils import format_disk_space
+
+_log = logging.getLogger(__name__)
+
+# Global client instance
+_client = None
+
+def get_client():
+    global _client
+    if _client is None:
+        _client = IDCClient.client()
+    # Ensure index is registered in duckdb
+    _client.sql_query("SELECT 1 FROM index LIMIT 1")
+    return _client
+
+# Mapping IDC columns to NBIA columns
+COLUMN_MAPPING = {
+    'collection_id': 'Collection',
+    'PatientID': 'PatientID',
+    'SeriesInstanceUID': 'SeriesInstanceUID',
+    'StudyInstanceUID': 'StudyInstanceUID',
+    'Modality': 'Modality',
+    'BodyPartExamined': 'BodyPartExamined',
+    'Manufacturer': 'Manufacturer',
+    'ManufacturerModelName': 'ManufacturerModelName',
+    'StudyDate': 'StudyDate',
+    'SeriesDate': 'SeriesDate',
+    'SeriesDescription': 'SeriesDescription',
+    'SeriesNumber': 'SeriesNumber',
+    'instanceCount': 'ImageCount',
+    'license_short_name': 'LicenseName',
+    'source_DOI': 'DataDescriptionURI',
+    'series_size_MB': 'FileSize'
+}
+
+def format_output(df: pd.DataFrame, format: str = "json", max_rows: int = 20):
+    if df.empty:
+        if format == "json":
+            return []
+        return df
+
+    # Standardize column names
+    df = df.rename(columns=COLUMN_MAPPING)
+
+    if format == "df":
+        return df
+    elif format == "csv":
+        csv_filename = f"idc_query_{datetime.now().strftime('%Y-%m-%d_%H-%M')}.csv"
+        df.to_csv(csv_filename, index=False)
+        _log.info(f"CSV saved to: {csv_filename}")
+        return df
+    elif format == "html":
+        return idcOhifViewer(df, max_rows=max_rows)
+    else: # default json
+        return df.to_dict(orient='records')
+
+def getCollections(format: str = ""):
+    client = get_client()
+    collections = client.get_collections()
+    df = pd.DataFrame(collections, columns=['collection_id'])
+    return format_output(df, format=format)
+
+def getBodyPart(collection: str = "", modality: str = "", format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT BodyPartExamined FROM index WHERE 1=1"
+    params = []
+    if collection:
+        query += " AND collection_id = ?"
+        params.append(collection)
+    if modality:
+        query += " AND Modality = ?"
+        params.append(modality)
+
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getModality(collection: str = "", bodyPart: str = "", format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT Modality FROM index WHERE 1=1"
+    params = []
+    if collection:
+        query += " AND collection_id = ?"
+        params.append(collection)
+    if bodyPart:
+        query += " AND BodyPartExamined = ?"
+        params.append(bodyPart)
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getPatient(collection: str = "", format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT collection_id, PatientID, PatientSex, PatientAge FROM index WHERE 1=1"
+    params = []
+    if collection:
+        query += " AND collection_id = ?"
+        params.append(collection)
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getPatientByCollectionAndModality(collection: str, modality: str, format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT PatientID FROM index WHERE collection_id = ? AND Modality = ?"
+    params = [collection, modality]
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getStudy(collection: str, patientId: str = "", studyUid: str = "", format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT collection_id, PatientID, StudyInstanceUID, StudyDate, StudyDescription FROM index WHERE collection_id = ?"
+    params = [collection]
+    if patientId:
+        query += " AND PatientID = ?"
+        params.append(patientId)
+    if studyUid:
+        query += " AND StudyInstanceUID = ?"
+        params.append(studyUid)
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getSeries(collection: str = "", patientId: str = "", studyUid: str = "", seriesUid: str = "",
+              modality: str = "", bodyPart: str = "", manufacturer: str = "", manufacturerModel: str = "",
+              format: str = ""):
+    client = get_client()
+    query = "SELECT * FROM index WHERE 1=1"
+    params = []
+    if collection:
+        query += " AND collection_id = ?"
+        params.append(collection)
+    if patientId:
+        query += " AND PatientID = ?"
+        params.append(patientId)
+    if studyUid:
+        query += " AND StudyInstanceUID = ?"
+        params.append(studyUid)
+    if seriesUid:
+        query += " AND SeriesInstanceUID = ?"
+        params.append(seriesUid)
+    if modality:
+        query += " AND Modality = ?"
+        params.append(modality)
+    if bodyPart:
+        query += " AND BodyPartExamined = ?"
+        params.append(bodyPart)
+    if manufacturer:
+        query += " AND Manufacturer = ?"
+        params.append(manufacturer)
+    if manufacturerModel:
+        query += " AND ManufacturerModelName = ?"
+        params.append(manufacturerModel)
+
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def getSeriesList(uids: List[str], format: str = "df"):
+    client = get_client()
+    if not uids:
+        return format_output(pd.DataFrame(), format=format)
+    placeholders = ",".join(["?" for _ in uids])
+    query = f"SELECT * FROM index WHERE SeriesInstanceUID IN ({placeholders})"
+    df = client._duckdb_conn.execute(query, uids).df()
+    return format_output(df, format=format)
+
+def getSopInstanceUids(seriesUid: str, format: str = ""):
+    _log.warning("getSopInstanceUids is not supported by idc-index 'index' table.")
+    return []
+
+def getManufacturer(collection: str = "", modality: str = "", bodyPart: str = "", format: str = ""):
+    client = get_client()
+    query = "SELECT DISTINCT Manufacturer, ManufacturerModelName FROM index WHERE 1=1"
+    params = []
+    if collection:
+        query += " AND collection_id = ?"
+        params.append(collection)
+    if modality:
+        query += " AND Modality = ?"
+        params.append(modality)
+    if bodyPart:
+        query += " AND BodyPartExamined = ?"
+        params.append(bodyPart)
+    df = client._duckdb_conn.execute(query, params).df()
+    return format_output(df, format=format)
+
+def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
+                   number: int = 0,
+                   path: str = "idcDownload",
+                   input_type: str = "",
+                   format: str = "",
+                   max_workers: int = 10):
+    client = get_client()
+    uids = []
+    if input_type == "list":
+        uids = series_data
+    elif input_type == "df":
+        uids = series_data['SeriesInstanceUID'].tolist()
+    elif isinstance(series_data, str):
+        if series_data.endswith(".tcia") or series_data.endswith(".txt"):
+            with open(series_data, 'r') as f:
+                uids = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+        else:
+            uids = [series_data]
+    else:
+        uids = [item['SeriesInstanceUID'] for item in series_data]
+
+    if number > 0:
+        uids = uids[:number]
+
+    _log.info(f"Downloading {len(uids)} series to {path}...")
+    client.download_dicom_series(seriesInstanceUID=uids, downloadDir=path)
+
+    if format == "df":
+        return getSeriesList(uids)
+    return None
+
+def downloadImage(seriesUID: str, sopUID: str, path: str = "idcDownload"):
+    client = get_client()
+    client.download_dicom_instance(sopInstanceUID=sopUID, downloadDir=path)
+
+def getDicomTags(seriesUid: str, format: str = "df"):
+    _log.warning("getDicomTags is not supported by idc-index.")
+    return None
+
+def getSegRefSeries(uid: str):
+    client = get_client()
+    try:
+        client.fetch_index('seg_index')
+        # Ensure it's registered
+        client.sql_query("SELECT 1 FROM seg_index LIMIT 1")
+        query = "SELECT segmented_SeriesInstanceUID FROM seg_index WHERE SeriesInstanceUID = ?"
+        df = client._duckdb_conn.execute(query, [uid]).df()
+        if not df.empty:
+            return df.iloc[0]['segmented_SeriesInstanceUID']
+
+        client.fetch_index('rtstruct_index')
+        client.sql_query("SELECT 1 FROM rtstruct_index LIMIT 1")
+        query = "SELECT referenced_SeriesInstanceUID FROM rtstruct_index WHERE SeriesInstanceUID = ?"
+        df = client._duckdb_conn.execute(query, [uid]).df()
+        if not df.empty:
+            return df.iloc[0]['referenced_SeriesInstanceUID']
+    except Exception as e:
+        _log.error(f"Error in getSegRefSeries: {e}")
+
+    _log.warning(f"Could not find reference series for {uid}")
+    return "N/A"
+
+def idcOhifViewer(data: Union[pd.DataFrame, List[dict]], max_rows: int = 500) -> Optional[HTML]:
+    if isinstance(data, list):
+        df = pd.DataFrame(data)
+    elif isinstance(data, pd.DataFrame):
+        df = data.copy()
+    else:
+        return None
+
+    if df.empty:
+        return None
+
+    if len(df) > max_rows:
+        df = df.head(max_rows)
+
+    base_url = "https://viewer.imaging.datacommons.cancer.gov/v3/viewer/"
+
+    if 'SeriesInstanceUID' in df.columns and 'StudyInstanceUID' in df.columns:
+        df['SeriesInstanceUID'] = df.apply(
+            lambda row: f'<a href="{base_url}?StudyInstanceUIDs={row["StudyInstanceUID"]}&SeriesInstanceUIDs={row["SeriesInstanceUID"]}" target="_blank">{row["SeriesInstanceUID"]}</a>',
+            axis=1
+        )
+
+    if 'StudyInstanceUID' in df.columns:
+        df['StudyInstanceUID'] = df['StudyInstanceUID'].apply(
+            lambda uid: f'<a href="{base_url}?StudyInstanceUIDs={uid}" target="_blank">{uid}</a>'
+        )
+
+    html_output = df.to_html(escape=False, index=False)
+    return HTML(html_output)
+
+def getCollectionDescriptions(format = ""):
+    client = get_client()
+    try:
+        client.fetch_index('collections_index')
+        query = "SELECT * FROM collections_index"
+        df = client.sql_query(query)
+        return format_output(df, format=format)
+    except Exception as e:
+        _log.error(f"Error in getCollectionDescriptions: {e}")
+    return None
+
+def reportDataSummary(series_data, input_type="", report_type = "", format=""):
+    uids = []
+    if input_type == "list":
+        uids = series_data
+    elif input_type == "df":
+        uids = series_data['SeriesInstanceUID'].tolist()
+    elif isinstance(series_data, str):
+        with open(series_data, 'r') as f:
+            uids = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    else:
+        uids = [item['SeriesInstanceUID'] for item in series_data]
+
+    df = getSeriesList(uids, format="df")
+
+    if report_type == "doi":
+        group = "DataDescriptionURI"
+    else:
+        group = "Collection"
+
+    # Aggregation
+    summary = df.groupby(group).agg({
+        'Modality': 'unique',
+        'LicenseName': 'unique',
+        'Manufacturer': 'unique',
+        'BodyPartExamined': 'unique',
+        'PatientID': 'nunique',
+        'StudyInstanceUID': 'nunique',
+        'SeriesInstanceUID': 'nunique',
+        'ImageCount': 'sum',
+        'FileSize': 'sum'
+    }).reset_index()
+
+    summary.rename(columns={
+        'PatientID': 'Subjects',
+        'StudyInstanceUID': 'Studies',
+        'SeriesInstanceUID': 'Series',
+        'ImageCount': 'Images',
+        'FileSize': 'File Size MB'
+    }, inplace=True)
+
+    summary['Disk Space'] = (summary['File Size MB'] * 1024 * 1024).apply(format_disk_space)
+
+    if format == 'chart':
+        for metric in ['Subjects', 'Studies', 'Series', 'Images']:
+            fig = px.pie(summary, names=group, values=metric, title=f'{metric} Distribution')
+            fig.show()
+
+    if format == 'csv':
+        summary.to_csv(f"idc_{report_type}_report.csv", index=False)
+
+    return summary
+
+def reportCollectionSummary(series_data, input_type="", format=""):
+    return reportDataSummary(series_data, input_type, report_type="collection", format=format)
+
+def reportDoiSummary(series_data, input_type="", format=""):
+    return reportDataSummary(series_data, input_type, report_type="doi", format=format)

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -8,6 +8,10 @@ import os
 import plotly.express as px
 from tcia_utils.utils import format_disk_space
 import csv
+import warnings
+import requests
+import io
+import pydicom
 
 _log = logging.getLogger(__name__)
 
@@ -170,7 +174,29 @@ def getSeriesList(uids: List[str], format: str = "df"):
     return format_output(df, format=format)
 
 def getSopInstanceUids(seriesUid: str, format: str = ""):
-    _log.warning("getSopInstanceUids is not supported by idc-index 'index' table.")
+    client = get_client()
+    try:
+        urls = client.get_series_file_URLs(seriesUid)
+        if not urls:
+            return []
+
+        first_url = urls[0]
+        http_url = first_url.replace("s3://idc-open-data/", "https://idc-open-data.s3.amazonaws.com/")
+        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'})
+        if resp.status_code in [200, 206]:
+            with io.BytesIO(resp.content) as f:
+                ds = pydicom.dcmread(f, stop_before_pixels=True)
+                filename_uid = os.path.basename(first_url).replace(".dcm", "")
+                if ds.SOPInstanceUID != filename_uid:
+                    _log.warning("SOPInstanceUID may not match file names. Returning instance UUIDs.")
+
+                uids = [os.path.basename(url).replace(".dcm", "") for url in urls]
+                if format == "df":
+                    return pd.DataFrame(uids, columns=["SOPInstanceUID"])
+                else:
+                    return uids
+    except Exception as e:
+        _log.error(f"Error in getSopInstanceUids: {e}")
     return []
 
 def getManufacturer(collection: str = "", modality: str = "", bodyPart: str = "", format: str = ""):
@@ -190,9 +216,6 @@ def getManufacturer(collection: str = "", modality: str = "", bodyPart: str = ""
     return format_output(df, format=format)
 
 def _processManifest(manifest_path: str) -> Union[List[str], str]:
-    """
-    Processes various manifest types and returns a list of UIDs or the path to an s5cmd manifest.
-    """
     if manifest_path.endswith(".s5cmd"):
         return manifest_path
 
@@ -201,15 +224,12 @@ def _processManifest(manifest_path: str) -> Union[List[str], str]:
             first_line = f.readline().strip()
             f.seek(0)
 
-            # Check for NBIA manifest
             if first_line.startswith("downloadServerUrl="):
                 _log.info("Detected NBIA manifest.")
                 lines = f.readlines()
-                # Skip first 6 lines of metadata
                 uids = [line.strip() for line in lines[6:] if line.strip()]
                 return uids
 
-            # Check for CSV/TSV
             if manifest_path.endswith((".csv", ".tsv")):
                 delimiter = "," if manifest_path.endswith(".csv") else "\t"
                 df = pd.read_csv(manifest_path, sep=delimiter)
@@ -218,7 +238,6 @@ def _processManifest(manifest_path: str) -> Union[List[str], str]:
                         _log.info(f"Detected {col} in CSV/TSV manifest.")
                         return df[col].dropna().astype(str).tolist()
 
-            # Default: treat as one UID per line
             _log.info("Treating manifest as one UID per line.")
             return [line.strip() for line in f if line.strip() and not line.startswith("#")]
 
@@ -271,14 +290,43 @@ def downloadImage(seriesUID: str, sopUID: str, path: str = "idcDownload"):
     client.download_dicom_instance(sopInstanceUID=sopUID, downloadDir=path)
 
 def getDicomTags(seriesUid: str, format: str = "df"):
-    _log.warning("getDicomTags is not supported by idc-index.")
+    client = get_client()
+    try:
+        urls = client.get_series_file_URLs(seriesUid)
+        if not urls:
+            return None
+
+        s3_url = urls[0]
+        http_url = s3_url.replace("s3://idc-open-data/", "https://idc-open-data.s3.amazonaws.com/")
+
+        _log.info(f"Fetching DICOM tags from {http_url}")
+        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'})
+        if resp.status_code in [200, 206]:
+            with io.BytesIO(resp.content) as f:
+                ds = pydicom.dcmread(f, stop_before_pixels=True)
+
+                tag_data = []
+                for element in ds:
+                    if element.tag.group < 0x7fe0:
+                        tag_data.append({
+                            "element": f"({element.tag.group:04x},{element.tag.element:04x})",
+                            "name": element.name,
+                            "data": str(element.value)
+                        })
+
+                df = pd.DataFrame(tag_data)
+                if format == "df":
+                    return df
+                else:
+                    return tag_data
+    except Exception as e:
+        _log.error(f"Error in getDicomTags: {e}")
     return None
 
 def getSegRefSeries(uid: str):
     client = get_client()
     try:
         client.fetch_index('seg_index')
-        # Ensure it's registered
         client.sql_query("SELECT 1 FROM seg_index LIMIT 1")
         query = "SELECT segmented_SeriesInstanceUID FROM seg_index WHERE SeriesInstanceUID = ?"
         df = client._duckdb_conn.execute(query, [uid]).df()
@@ -465,6 +513,11 @@ def getSimpleSearch(
         where_clauses.append("StudyDate <= ?")
         params.append(isoToDate)
 
+    if minStudies > 0:
+        # Number of studies a patient has
+        where_clauses.append("PatientID IN (SELECT PatientID FROM index GROUP BY PatientID HAVING COUNT(DISTINCT StudyInstanceUID) >= ?)")
+        params.append(minStudies)
+
     if where_clauses:
         query += " WHERE " + " AND ".join(where_clauses)
 
@@ -485,7 +538,7 @@ def getSimpleSearch(
     order = "ASC" if sortDirection == 'ascending' else "DESC"
     query += f" ORDER BY {field} {order}"
 
-    if format not in ["uids", "manifest_text"]:
+    if format not in ["uids", "manifest_text", "manifest"]:
         query += f" LIMIT {size} OFFSET {start}"
 
     df = client._duckdb_conn.execute(query, params).df()
@@ -494,5 +547,75 @@ def getSimpleSearch(
         return df['SeriesInstanceUID'].tolist()
     elif format == "manifest_text":
         return "\n".join(df['SeriesInstanceUID'].tolist())
+    elif format == "manifest":
+        uids = df['SeriesInstanceUID'].tolist()
+        manifest_df = getSeriesList(uids, format="df")
+        now = datetime.now()
+        filename = now.strftime("manifest-%Y-%m-%d_%H-%M.csv")
+        manifest_df.to_csv(filename, index=False)
+        _log.info(f"Manifest saved as {filename}")
+        return manifest_df
 
     return format_output(df, format=format)
+
+# Unsupported function stubs with warnings
+
+def setApiUrl(*args, **kwargs):
+    warnings.warn("setApiUrl is not supported in the IDC module.", UserWarning)
+    return None
+
+def getSeriesSize(*args, **kwargs):
+    warnings.warn("getSeriesSize is not supported in the IDC module.", UserWarning)
+    return None
+
+def getSharedCart(*args, **kwargs):
+    warnings.warn("getSharedCart is not supported in the IDC module.", UserWarning)
+    return None
+
+def makeSeriesReport(*args, **kwargs):
+    warnings.warn("makeSeriesReport is not supported in the IDC module.", UserWarning)
+    return None
+
+def reportSeriesSubmissionDate(*args, **kwargs):
+    warnings.warn("reportSeriesSubmissionDate is not supported in the IDC module.", UserWarning)
+    return None
+
+def reportSeriesReleaseDate(*args, **kwargs):
+    warnings.warn("reportSeriesReleaseDate is not supported in the IDC module.", UserWarning)
+    return None
+
+def getNewPatientsInCollection(*args, **kwargs):
+    warnings.warn("getNewPatientsInCollection is not supported in the IDC module.", UserWarning)
+    return None
+
+def getNewStudiesInPatient(*args, **kwargs):
+    warnings.warn("getNewStudiesInPatient is not supported in the IDC module.", UserWarning)
+    return None
+
+def getUpdatedSeries(*args, **kwargs):
+    warnings.warn("getUpdatedSeries is not supported in the IDC module.", UserWarning)
+    return None
+
+def getDoiMetadata(*args, **kwargs):
+    warnings.warn("getDoiMetadata is not supported in the IDC module.", UserWarning)
+    return None
+
+def getCollectionPatientCounts(*args, **kwargs):
+    warnings.warn("getCollectionPatientCounts is not supported in the IDC module.", UserWarning)
+    return None
+
+def getModalityCounts(*args, **kwargs):
+    warnings.warn("getModalityCounts is not supported in the IDC module.", UserWarning)
+    return None
+
+def getBodyPartCounts(*args, **kwargs):
+    warnings.warn("getBodyPartCounts is not supported in the IDC module.", UserWarning)
+    return None
+
+def getManufacturerCounts(*args, **kwargs):
+    warnings.warn("getManufacturerCounts is not supported in the IDC module.", UserWarning)
+    return None
+
+def reportDicomTags(*args, **kwargs):
+    warnings.warn("reportDicomTags is not supported in the IDC module.", UserWarning)
+    return None

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -12,6 +12,13 @@ import warnings
 import requests
 import io
 import pydicom
+import shutil
+import zipfile
+try:
+    import dicom2nifti
+    import dicom2nifti.settings as settings
+except ImportError:
+    dicom2nifti = None
 
 _log = logging.getLogger(__name__)
 
@@ -250,6 +257,8 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
                    path: str = "idcDownload",
                    input_type: str = "",
                    format: str = "",
+                   as_zip: bool = False,
+                   as_nifti: bool = False,
                    max_workers: int = 10):
     client = get_client()
     uids = []
@@ -276,7 +285,48 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
         client.download_from_manifest(manifestFile=s5cmd_manifest, downloadDir=path)
     elif uids:
         _log.info(f"Downloading {len(uids)} series to {path}...")
+        meta_df = getSeriesList(uids, format="df")
         client.download_dicom_series(seriesInstanceUID=uids, downloadDir=path)
+
+        # Post-processing
+        for _, row in meta_df.iterrows():
+            series_uid = row['SeriesInstanceUID']
+            patient_id = row['PatientID']
+            collection_id = row['Collection']
+            study_uid = row['StudyInstanceUID']
+            modality = row['Modality']
+
+            series_folder = os.path.join(path, collection_id, patient_id, study_uid, f"{modality}_{series_uid}")
+
+            if not os.path.exists(series_folder):
+                _log.warning(f"Could not find downloaded folder for series {series_uid} at {series_folder}")
+                continue
+
+            if as_nifti:
+                if dicom2nifti is None:
+                    _log.error("dicom2nifti not installed. Skipping NIfTI conversion.")
+                else:
+                    _log.info(f"Converting series {series_uid} to NIfTI...")
+                    try:
+                        settings.disable_validate_slicecount()
+                        # We need an output filename for dicom_series_to_nifti
+                        nifti_output = os.path.join(series_folder, f"{series_uid}.nii.gz")
+                        dicom2nifti.dicom_series_to_nifti(series_folder, nifti_output, reorient_nifti=True)
+                        for f in os.listdir(series_folder):
+                            if f.endswith(".dcm"):
+                                os.remove(os.path.join(series_folder, f))
+                    except Exception as e:
+                        _log.error(f"Error converting {series_uid} to NIfTI: {e}")
+
+            if as_zip:
+                _log.info(f"Zipping series {series_uid}...")
+                zip_path = series_folder + ".zip"
+                with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+                    for root, dirs, files in os.walk(series_folder):
+                        for file in files:
+                            zipf.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), os.path.join(series_folder, '..')))
+                shutil.rmtree(series_folder)
+
     else:
         _log.warning("No data found to download.")
         return None
@@ -514,7 +564,6 @@ def getSimpleSearch(
         params.append(isoToDate)
 
     if minStudies > 0:
-        # Number of studies a patient has
         where_clauses.append("PatientID IN (SELECT PatientID FROM index GROUP BY PatientID HAVING COUNT(DISTINCT StudyInstanceUID) >= ?)")
         params.append(minStudies)
 

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -12,13 +12,6 @@ import warnings
 import requests
 import io
 import pydicom
-import shutil
-import zipfile
-try:
-    import dicom2nifti
-    import dicom2nifti.settings as settings
-except ImportError:
-    dicom2nifti = None
 
 _log = logging.getLogger(__name__)
 
@@ -257,8 +250,6 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
                    path: str = "idcDownload",
                    input_type: str = "",
                    format: str = "",
-                   as_zip: bool = False,
-                   as_nifti: bool = False,
                    max_workers: int = 10):
     client = get_client()
     uids = []
@@ -285,48 +276,7 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
         client.download_from_manifest(manifestFile=s5cmd_manifest, downloadDir=path)
     elif uids:
         _log.info(f"Downloading {len(uids)} series to {path}...")
-        meta_df = getSeriesList(uids, format="df")
         client.download_dicom_series(seriesInstanceUID=uids, downloadDir=path)
-
-        # Post-processing
-        for _, row in meta_df.iterrows():
-            series_uid = row['SeriesInstanceUID']
-            patient_id = row['PatientID']
-            collection_id = row['Collection']
-            study_uid = row['StudyInstanceUID']
-            modality = row['Modality']
-
-            series_folder = os.path.join(path, collection_id, patient_id, study_uid, f"{modality}_{series_uid}")
-
-            if not os.path.exists(series_folder):
-                _log.warning(f"Could not find downloaded folder for series {series_uid} at {series_folder}")
-                continue
-
-            if as_nifti:
-                if dicom2nifti is None:
-                    _log.error("dicom2nifti not installed. Skipping NIfTI conversion.")
-                else:
-                    _log.info(f"Converting series {series_uid} to NIfTI...")
-                    try:
-                        settings.disable_validate_slicecount()
-                        # We need an output filename for dicom_series_to_nifti
-                        nifti_output = os.path.join(series_folder, f"{series_uid}.nii.gz")
-                        dicom2nifti.dicom_series_to_nifti(series_folder, nifti_output, reorient_nifti=True)
-                        for f in os.listdir(series_folder):
-                            if f.endswith(".dcm"):
-                                os.remove(os.path.join(series_folder, f))
-                    except Exception as e:
-                        _log.error(f"Error converting {series_uid} to NIfTI: {e}")
-
-            if as_zip:
-                _log.info(f"Zipping series {series_uid}...")
-                zip_path = series_folder + ".zip"
-                with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-                    for root, dirs, files in os.walk(series_folder):
-                        for file in files:
-                            zipf.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), os.path.join(series_folder, '..')))
-                shutil.rmtree(series_folder)
-
     else:
         _log.warning("No data found to download.")
         return None
@@ -564,6 +514,7 @@ def getSimpleSearch(
         params.append(isoToDate)
 
     if minStudies > 0:
+        # Number of studies a patient has
         where_clauses.append("PatientID IN (SELECT PatientID FROM index GROUP BY PatientID HAVING COUNT(DISTINCT StudyInstanceUID) >= ?)")
         params.append(minStudies)
 

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from idc_index import IDCClient
 from IPython.display import HTML
 import os
-import concurrent.futures
 import plotly.express as px
 from tcia_utils.utils import format_disk_space
 
@@ -232,7 +231,6 @@ def getSegRefSeries(uid: str):
     client = get_client()
     try:
         client.fetch_index('seg_index')
-        # Ensure it's registered
         client.sql_query("SELECT 1 FROM seg_index LIMIT 1")
         query = "SELECT segmented_SeriesInstanceUID FROM seg_index WHERE SeriesInstanceUID = ?"
         df = client._duckdb_conn.execute(query, [uid]).df()
@@ -349,3 +347,104 @@ def reportCollectionSummary(series_data, input_type="", format=""):
 
 def reportDoiSummary(series_data, input_type="", format=""):
     return reportDataSummary(series_data, input_type, report_type="doi", format=format)
+
+def getSimpleSearch(
+    collections = [],
+    species = [],
+    modalities = [],
+    bodyParts = [],
+    manufacturers  = [],
+    fromDate = "",
+    toDate = "",
+    patients = [],
+    minStudies: int = 0,
+    modalityAnded = False,
+    start = 0,
+    size = 10,
+    sortDirection = 'ascending',
+    sortField = 'subject',
+    format = ""):
+
+    client = get_client()
+
+    query = "SELECT * FROM index"
+    params = []
+    where_clauses = []
+
+    if collections:
+        placeholders = ",".join(["?" for _ in collections])
+        where_clauses.append(f"collection_id IN ({placeholders})")
+        params.extend(collections)
+
+    if species:
+        client.fetch_index('collections_index')
+        client.sql_query("SELECT 1 FROM collections_index LIMIT 1")
+        placeholders = ",".join(["?" for _ in species])
+        where_clauses.append(f"collection_id IN (SELECT collection_id FROM collections_index WHERE Species IN ({placeholders}))")
+        # Species in collections_index are like 'Human', 'Mouse', etc.
+        # NBIA uses lowercase 'human'. Let's title case them for IDC.
+        params.extend([s.title() for s in species])
+
+    if modalities:
+        placeholders = ",".join(["?" for _ in modalities])
+        where_clauses.append(f"Modality IN ({placeholders})")
+        params.extend(modalities)
+
+    if bodyParts:
+        placeholders = ",".join(["?" for _ in bodyParts])
+        where_clauses.append(f"BodyPartExamined IN ({placeholders})")
+        params.extend(bodyParts)
+
+    if manufacturers:
+        placeholders = ",".join(["?" for _ in manufacturers])
+        where_clauses.append(f"Manufacturer IN ({placeholders})")
+        params.extend(manufacturers)
+
+    if patients:
+        placeholders = ",".join(["?" for _ in patients])
+        where_clauses.append(f"PatientID IN ({placeholders})")
+        params.extend(patients)
+
+    if fromDate:
+        # IDC StudyDate is YYYY-MM-DD
+        isoFromDate = fromDate.replace("/", "-")
+        where_clauses.append("StudyDate >= ?")
+        params.append(isoFromDate)
+
+    if toDate:
+        isoToDate = toDate.replace("/", "-")
+        where_clauses.append("StudyDate <= ?")
+        params.append(isoToDate)
+
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
+
+    if modalityAnded and modalities:
+        # Patients that have ALL the requested modalities
+        placeholders = ",".join(["?" for _ in modalities])
+        query += f" AND PatientID IN (SELECT PatientID FROM index WHERE Modality IN ({placeholders}) GROUP BY PatientID HAVING COUNT(DISTINCT Modality) = ?)"
+        params.extend(modalities)
+        params.append(len(modalities))
+
+    # Sorting
+    sort_map = {
+        'subject': 'PatientID',
+        'studies': 'StudyInstanceUID',
+        'series': 'SeriesInstanceUID',
+        'collection': 'collection_id'
+    }
+    field = sort_map.get(sortField, 'PatientID')
+    order = "ASC" if sortDirection == 'ascending' else "DESC"
+    query += f" ORDER BY {field} {order}"
+
+    if format not in ["uids", "manifest_text"]:
+        query += f" LIMIT {size} OFFSET {start}"
+
+    df = client._duckdb_conn.execute(query, params).df()
+
+    if format == "uids":
+        return df['SeriesInstanceUID'].tolist()
+    elif format == "manifest_text":
+        return "\n".join(df['SeriesInstanceUID'].tolist())
+
+    return format_output(df, format=format)

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -2,7 +2,6 @@ import unittest
 import pandas as pd
 import os
 import glob
-import shutil
 from tcia_utils import idc
 
 class TestIDC(unittest.TestCase):
@@ -78,7 +77,7 @@ class TestIDC(unittest.TestCase):
         self.assertIn("SeriesInstanceUID", df.columns)
 
         manifest_files = glob.glob("manifest-*.csv")
-        self.assertGreater(len(manifest_files), 0)
+        self.assertEqual(len(manifest_files), 1)
         for f in manifest_files:
             os.remove(f)
 
@@ -126,33 +125,6 @@ class TestIDC(unittest.TestCase):
     def test_unsupported_warnings(self):
         with self.assertWarns(UserWarning):
             idc.getSharedCart("test")
-
-    def test_downloadSeries_zip(self):
-        path = "testDownloadZip"
-        if os.path.exists(path):
-            shutil.rmtree(path)
-        series = idc.getSeries(collection="rider_pilot", modality="SR", format="json")
-        if series:
-            uid = series[0]["SeriesInstanceUID"]
-            idc.downloadSeries([{'SeriesInstanceUID': uid}], path=path, as_zip=True)
-            zip_files = glob.glob(os.path.join(path, "**", "*.zip"), recursive=True)
-            self.assertGreater(len(zip_files), 0)
-        shutil.rmtree(path)
-
-    def test_downloadSeries_nifti(self):
-        path = "testDownloadNifti"
-        if os.path.exists(path):
-            shutil.rmtree(path)
-        # 4D-Lung series for NIfTI (larger stack than rider_pilot SR/single slices)
-        series = idc.getSeries(collection="4d_lung", modality="CT", format="json")
-        if series:
-            df = pd.DataFrame(series)
-            valid_series = df[df['ImageCount'] > 20].iloc[0]
-            uid = valid_series['SeriesInstanceUID']
-            idc.downloadSeries([{'SeriesInstanceUID': uid}], path=path, as_nifti=True)
-            nifti_files = glob.glob(os.path.join(path, "**", "*.nii.gz"), recursive=True)
-            self.assertGreater(len(nifti_files), 0)
-        shutil.rmtree(path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -1,5 +1,6 @@
 import unittest
 import pandas as pd
+import os
 from tcia_utils import idc
 
 class TestIDC(unittest.TestCase):
@@ -67,6 +68,29 @@ class TestIDC(unittest.TestCase):
         self.assertIsInstance(uids, list)
         self.assertGreater(len(uids), 0)
         self.assertIsInstance(uids[0], str)
+
+    def test_manifest_nbia(self):
+        content = "downloadServerUrl=https://public.cancerimagingarchive.net/nbia-download/servlet/DownloadServlet\nline2\nline3\nline4\nline5\nline6\nUID1\nUID2"
+        with open("test_nbia.tcia", "w") as f:
+            f.write(content)
+        uids = idc._processManifest("test_nbia.tcia")
+        self.assertEqual(uids, ["UID1", "UID2"])
+        os.remove("test_nbia.tcia")
+
+    def test_manifest_csv(self):
+        df = pd.DataFrame({"SeriesInstanceUID": ["UID1", "UID2"], "Other": [1, 2]})
+        df.to_csv("test.csv", index=False)
+        uids = idc._processManifest("test.csv")
+        self.assertEqual(uids, ["UID1", "UID2"])
+        os.remove("test.csv")
+
+    def test_manifest_s5cmd(self):
+        manifest_path = "test.s5cmd"
+        with open(manifest_path, "w") as f:
+            f.write("cp s3://bucket/obj ./dest")
+        processed = idc._processManifest(manifest_path)
+        self.assertEqual(processed, manifest_path)
+        os.remove(manifest_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -1,0 +1,63 @@
+import unittest
+import pandas as pd
+from tcia_utils import idc
+
+class TestIDC(unittest.TestCase):
+    def test_getCollections(self):
+        collections = idc.getCollections(format="df")
+        self.assertIsInstance(collections, pd.DataFrame)
+        self.assertIn("Collection", collections.columns)
+        self.assertGreater(len(collections), 0)
+
+    def test_getSeries(self):
+        series = idc.getSeries(collection="rider_pilot", format="df")
+        self.assertIsInstance(series, pd.DataFrame)
+        self.assertIn("SeriesInstanceUID", series.columns)
+        self.assertIn("Collection", series.columns)
+        self.assertEqual(series["Collection"].iloc[0], "rider_pilot")
+
+    def test_getPatient(self):
+        patients = idc.getPatient(collection="rider_pilot", format="df")
+        self.assertIsInstance(patients, pd.DataFrame)
+        self.assertIn("PatientID", patients.columns)
+        self.assertGreater(len(patients), 0)
+
+    def test_getModality(self):
+        modalities = idc.getModality(collection="rider_pilot", format="df")
+        self.assertIsInstance(modalities, pd.DataFrame)
+        self.assertIn("Modality", modalities.columns)
+
+    def test_getBodyPart(self):
+        body_parts = idc.getBodyPart(collection="rider_pilot", format="df")
+        self.assertIsInstance(body_parts, pd.DataFrame)
+        self.assertIn("BodyPartExamined", body_parts.columns)
+
+    def test_getSeriesList(self):
+        # First get some UIDs
+        series = idc.getSeries(collection="rider_pilot", format="json")
+        uids = [s["SeriesInstanceUID"] for s in series[:2]]
+        series_list = idc.getSeriesList(uids, format="df")
+        self.assertEqual(len(series_list), 2)
+        self.assertIn(uids[0], series_list["SeriesInstanceUID"].values)
+
+    def test_getSegRefSeries(self):
+        # We need a known SEG or RTSTRUCT series.
+        # From previous exploration: rider_pilot has an SR with UID
+        # 1.2.276.0.7230010.3.1.3.1031255639.2476.1345992261.66
+        # Let's find an RTSTRUCT in 4d_lung
+        series = idc.getSeries(collection="4d_lung", modality="RTSTRUCT", format="json")
+        if series:
+            uid = series[0]["SeriesInstanceUID"]
+            ref_uid = idc.getSegRefSeries(uid)
+            self.assertNotEqual(ref_uid, "N/A")
+            self.assertTrue(ref_uid.startswith("1."))
+
+    def test_reportCollectionSummary(self):
+        series = idc.getSeries(collection="rider_pilot", format="json")
+        summary = idc.reportCollectionSummary(series[:5])
+        self.assertIsInstance(summary, pd.DataFrame)
+        self.assertIn("Collection", summary.columns)
+        self.assertIn("Subjects", summary.columns)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 import os
+import glob
 from tcia_utils import idc
 
 class TestIDC(unittest.TestCase):
@@ -34,7 +35,6 @@ class TestIDC(unittest.TestCase):
         self.assertIn("BodyPartExamined", body_parts.columns)
 
     def test_getSeriesList(self):
-        # First get some UIDs
         series = idc.getSeries(collection="rider_pilot", format="json")
         uids = [s["SeriesInstanceUID"] for s in series[:2]]
         series_list = idc.getSeriesList(uids, format="df")
@@ -57,17 +57,29 @@ class TestIDC(unittest.TestCase):
         self.assertIn("Subjects", summary.columns)
 
     def test_getSimpleSearch(self):
-        # Test basic search
         results = idc.getSimpleSearch(collections=["rider_pilot"], modalities=["CT"], format="df")
         self.assertIsInstance(results, pd.DataFrame)
         self.assertGreater(len(results), 0)
         self.assertTrue(all(results["Collection"] == "rider_pilot"))
 
-        # Test uids format
         uids = idc.getSimpleSearch(collections=["rider_pilot"], format="uids")
         self.assertIsInstance(uids, list)
         self.assertGreater(len(uids), 0)
         self.assertIsInstance(uids[0], str)
+
+    def test_getSimpleSearch_manifest(self):
+        manifest_files = glob.glob("manifest-*.csv")
+        for f in manifest_files:
+            os.remove(f)
+
+        df = idc.getSimpleSearch(collections=["rider_pilot"], format="manifest")
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertIn("SeriesInstanceUID", df.columns)
+
+        manifest_files = glob.glob("manifest-*.csv")
+        self.assertEqual(len(manifest_files), 1)
+        for f in manifest_files:
+            os.remove(f)
 
     def test_manifest_nbia(self):
         content = "downloadServerUrl=https://public.cancerimagingarchive.net/nbia-download/servlet/DownloadServlet\nline2\nline3\nline4\nline5\nline6\nUID1\nUID2"
@@ -91,6 +103,28 @@ class TestIDC(unittest.TestCase):
         processed = idc._processManifest(manifest_path)
         self.assertEqual(processed, manifest_path)
         os.remove(manifest_path)
+
+    def test_getDicomTags(self):
+        series = idc.getSeries(collection="rider_pilot", format="json")
+        if series:
+            uid = series[0]["SeriesInstanceUID"]
+            tags = idc.getDicomTags(uid)
+            self.assertIsInstance(tags, pd.DataFrame)
+            self.assertIn("element", tags.columns)
+            self.assertIn("name", tags.columns)
+            self.assertIn("data", tags.columns)
+
+    def test_getSopInstanceUids(self):
+        series = idc.getSeries(collection="rider_pilot", format="json")
+        if series:
+            uid = series[0]["SeriesInstanceUID"]
+            sop_uids = idc.getSopInstanceUids(uid)
+            self.assertIsInstance(sop_uids, list)
+            self.assertGreater(len(sop_uids), 0)
+
+    def test_unsupported_warnings(self):
+        with self.assertWarns(UserWarning):
+            idc.getSharedCart("test")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -2,6 +2,7 @@ import unittest
 import pandas as pd
 import os
 import glob
+import shutil
 from tcia_utils import idc
 
 class TestIDC(unittest.TestCase):
@@ -77,7 +78,7 @@ class TestIDC(unittest.TestCase):
         self.assertIn("SeriesInstanceUID", df.columns)
 
         manifest_files = glob.glob("manifest-*.csv")
-        self.assertEqual(len(manifest_files), 1)
+        self.assertGreater(len(manifest_files), 0)
         for f in manifest_files:
             os.remove(f)
 
@@ -125,6 +126,33 @@ class TestIDC(unittest.TestCase):
     def test_unsupported_warnings(self):
         with self.assertWarns(UserWarning):
             idc.getSharedCart("test")
+
+    def test_downloadSeries_zip(self):
+        path = "testDownloadZip"
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        series = idc.getSeries(collection="rider_pilot", modality="SR", format="json")
+        if series:
+            uid = series[0]["SeriesInstanceUID"]
+            idc.downloadSeries([{'SeriesInstanceUID': uid}], path=path, as_zip=True)
+            zip_files = glob.glob(os.path.join(path, "**", "*.zip"), recursive=True)
+            self.assertGreater(len(zip_files), 0)
+        shutil.rmtree(path)
+
+    def test_downloadSeries_nifti(self):
+        path = "testDownloadNifti"
+        if os.path.exists(path):
+            shutil.rmtree(path)
+        # 4D-Lung series for NIfTI (larger stack than rider_pilot SR/single slices)
+        series = idc.getSeries(collection="4d_lung", modality="CT", format="json")
+        if series:
+            df = pd.DataFrame(series)
+            valid_series = df[df['ImageCount'] > 20].iloc[0]
+            uid = valid_series['SeriesInstanceUID']
+            idc.downloadSeries([{'SeriesInstanceUID': uid}], path=path, as_nifti=True)
+            nifti_files = glob.glob(os.path.join(path, "**", "*.nii.gz"), recursive=True)
+            self.assertGreater(len(nifti_files), 0)
+        shutil.rmtree(path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_idc.py
+++ b/tests/test_idc.py
@@ -41,10 +41,6 @@ class TestIDC(unittest.TestCase):
         self.assertIn(uids[0], series_list["SeriesInstanceUID"].values)
 
     def test_getSegRefSeries(self):
-        # We need a known SEG or RTSTRUCT series.
-        # From previous exploration: rider_pilot has an SR with UID
-        # 1.2.276.0.7230010.3.1.3.1031255639.2476.1345992261.66
-        # Let's find an RTSTRUCT in 4d_lung
         series = idc.getSeries(collection="4d_lung", modality="RTSTRUCT", format="json")
         if series:
             uid = series[0]["SeriesInstanceUID"]
@@ -58,6 +54,19 @@ class TestIDC(unittest.TestCase):
         self.assertIsInstance(summary, pd.DataFrame)
         self.assertIn("Collection", summary.columns)
         self.assertIn("Subjects", summary.columns)
+
+    def test_getSimpleSearch(self):
+        # Test basic search
+        results = idc.getSimpleSearch(collections=["rider_pilot"], modalities=["CT"], format="df")
+        self.assertIsInstance(results, pd.DataFrame)
+        self.assertGreater(len(results), 0)
+        self.assertTrue(all(results["Collection"] == "rider_pilot"))
+
+        # Test uids format
+        uids = idc.getSimpleSearch(collections=["rider_pilot"], format="uids")
+        self.assertIsInstance(uids, list)
+        self.assertGreater(len(uids), 0)
+        self.assertIsInstance(uids[0], str)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR introduces a new `idc.py` module to the `tcia_utils` package. This module is designed to mirror the functionality of the existing `nbia.py` module, but instead of querying the NBIA REST API, it retrieves DICOM metadata and data from the NCI Imaging Data Commons (IDC) using the `idc-index` PyPI package.

Key features:
- **Mirroring**: Core functions from `nbia.py` have been implemented in `idc.py` with identical signatures and return formats where possible.
- **Data Mapping**: IDC metadata fields are automatically mapped to NBIA field names (e.g., `collection_id` -> `Collection`, `instanceCount` -> `ImageCount`).
- **Downloads**: High-performance DICOM downloads are supported via `idc-index`'s integration with `s5cmd`.
- **Visualization**: Built-in support for generating IDC OHIF viewer links.
- **Security**: All SQL queries against the local IDC index are parameterized to prevent injection.
- **Reporting**: Summary reporting functions for collections and DOIs are included.

This change facilitates the transition from NBIA to IDC for users of the `tcia_utils` library while maintaining a familiar interface.

---
*PR created automatically by Jules for task [17401381253605579735](https://jules.google.com/task/17401381253605579735) started by @kirbyju*