### PR TITLE
Add global proxy support to tcia_utils

### DIFF
--- a/src/tcia_utils/datacite.py
+++ b/src/tcia_utils/datacite.py
@@ -5,6 +5,7 @@ import time
 import logging
 from tcia_utils.utils import searchDf
 from tcia_utils.utils import copy_df_cols
+from tcia_utils.utils import get_proxy
 
 
 _log = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ def getDoi(format = ""):
     _log.info(f'Calling... {datacite_url} with parameters {options}')
 
     try:
-        data = requests.get(datacite_url, headers = datacite_headers, params = options)
+        data = requests.get(datacite_url, headers = datacite_headers, params = options, proxies=get_proxy())
         data.raise_for_status()
 
         # check for empty results and format output
@@ -312,7 +313,7 @@ def getDerivedDois(dois, format='df'):
             'query': query,
             'rows': 1000  # Adjust as needed for pagination
         }
-        response = requests.get(base_url, params=params)
+        response = requests.get(base_url, params=params, proxies=get_proxy())
 
         if response.status_code == 200:
             data = response.json()
@@ -386,7 +387,7 @@ def getGithubMentions(token, delay=10, resume_from=None):
 
         try:
             # Make the request to the GitHub API
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, proxies=get_proxy())
 
             # Check if the request was successful
             if response.status_code == 200:

--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -7,6 +7,7 @@ from IPython.display import HTML
 import os
 import plotly.express as px
 from tcia_utils.utils import format_disk_space
+from tcia_utils.utils import get_proxy
 import csv
 import warnings
 import requests
@@ -182,7 +183,7 @@ def getSopInstanceUids(seriesUid: str, format: str = ""):
 
         first_url = urls[0]
         http_url = first_url.replace("s3://idc-open-data/", "https://idc-open-data.s3.amazonaws.com/")
-        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'})
+        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'}, proxies=get_proxy())
         if resp.status_code in [200, 206]:
             with io.BytesIO(resp.content) as f:
                 ds = pydicom.dcmread(f, stop_before_pixels=True)
@@ -300,7 +301,7 @@ def getDicomTags(seriesUid: str, format: str = "df"):
         http_url = s3_url.replace("s3://idc-open-data/", "https://idc-open-data.s3.amazonaws.com/")
 
         _log.info(f"Fetching DICOM tags from {http_url}")
-        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'})
+        resp = requests.get(http_url, headers={'Range': 'bytes=0-1048575'}, proxies=get_proxy())
         if resp.status_code in [200, 206]:
             with io.BytesIO(resp.content) as f:
                 ds = pydicom.dcmread(f, stop_before_pixels=True)

--- a/src/tcia_utils/nbia.py
+++ b/src/tcia_utils/nbia.py
@@ -18,6 +18,7 @@ from tcia_utils.utils import searchDf
 from tcia_utils.utils import copy_df_cols
 from tcia_utils.utils import format_disk_space
 from tcia_utils.utils import remove_html_tags
+from tcia_utils.utils import get_proxy
 from tcia_utils.datacite import getDoi
 from IPython.display import HTML
 
@@ -153,10 +154,10 @@ def queryData(
     try:
         if method.upper() == "POST":
             _log.info(f'Calling {endpoint} with parameters {param}')
-            response = requests.post(url, data=param)
+            response = requests.post(url, data=param, proxies=get_proxy())
         else:
             _log.info(f'Calling {endpoint} with parameters {options}')
-            response = requests.get(url, params=options)
+            response = requests.get(url, params=options, proxies=get_proxy())
 
         response.raise_for_status()
 
@@ -485,7 +486,7 @@ def getSeriesList(
         url = f"{base_url}{endpoint}"
 
         try:
-            response = requests.post(url, data=param)
+            response = requests.post(url, data=param, proxies=get_proxy())
             response.raise_for_status()
 
             if response and not response.content.strip():
@@ -630,7 +631,7 @@ def _download_and_unzip_series(seriesUID, path, api_url, downloadOptions, as_zip
         data_url = base_url + downloadOptions + seriesUID
 
         _log.info(f"Downloading... {data_url}")
-        data = requests.get(data_url)
+        data = requests.get(data_url, proxies=get_proxy())
 
         if data.status_code == 200:
             if as_zip:
@@ -800,7 +801,7 @@ def downloadImage(seriesUID: str, sopUID: str, path: Optional[str] = "", api_url
         if not os.path.isfile(file_path):
             data_url = f"{base_url}getSingleImage?SeriesInstanceUID={seriesUID}&SOPInstanceUID={sopUID}"
             _log.info(f"Downloading... {data_url}")
-            data = requests.get(data_url)
+            data = requests.get(data_url, proxies=get_proxy())
 
             if data.status_code == 200:
                 os.makedirs(path_tmp, exist_ok=True)
@@ -1159,7 +1160,7 @@ def getSimpleSearch(
 
     # get data & handle any request.post() errors
     try:
-        metadata = requests.post(url, data = options)
+        metadata = requests.post(url, data = options, proxies=get_proxy())
         metadata.raise_for_status()
 
         # check for empty results and format output

--- a/src/tcia_utils/pathdb.py
+++ b/src/tcia_utils/pathdb.py
@@ -6,6 +6,7 @@ import numpy as np
 import logging
 from tcia_utils.utils import searchDf
 from tcia_utils.utils import copy_df_cols
+from tcia_utils.utils import get_proxy
 import os
 from urllib.parse import urlparse
 import concurrent.futures
@@ -30,7 +31,7 @@ def getCollections(query = "", format = ""):
     extracted_data = []
     url = base_url + 'collections?_format=json'
     _log.info(f'Calling... {url}')
-    response = requests.get(url)
+    response = requests.get(url, proxies=get_proxy())
     if response.status_code == 200:
         data = response.json()
 
@@ -113,7 +114,7 @@ def getImages(query, format=""):
         while True:
             paginated_url = f"{url}&page={page}" if '?' in url else f"{url}?page={page}"
             _log.info(f'Calling... {paginated_url}')
-            response = requests.get(paginated_url)
+            response = requests.get(paginated_url, proxies=get_proxy())
 
             if response.status_code == 200:
                 data = response.json()
@@ -217,7 +218,7 @@ def _download_image(image_info, path):
 
         filepath = os.path.join(path, filename)
 
-        response = requests.get(image_url, stream=True, allow_redirects=True)
+        response = requests.get(image_url, stream=True, allow_redirects=True, proxies=get_proxy())
         response.raise_for_status()
 
         with open(filepath, "wb") as f:

--- a/src/tcia_utils/utils.py
+++ b/src/tcia_utils/utils.py
@@ -9,6 +9,33 @@ logging.basicConfig(
     level=logging.INFO
 )
 
+_proxies = None
+
+
+def set_proxy(proxies: dict):
+    """
+    Sets a global proxy configuration for all tcia_utils modules.
+
+    Example:
+    proxies = {
+        'http': 'http://10.10.1.10:3128',
+        'https': 'http://10.10.1.10:1080',
+    }
+    set_proxy(proxies)
+    """
+    global _proxies
+    _proxies = proxies
+    _log.info(f"Global proxy set to: {_proxies}")
+
+
+def get_proxy():
+    """
+    Returns the current global proxy configuration.
+    """
+    global _proxies
+    return _proxies
+
+
 def searchDf(search_term, dataframe=None, column_name=None):
     """
     This function searches for a term or a list of terms in a specified dataframe and column.

--- a/src/tcia_utils/wordpress.py
+++ b/src/tcia_utils/wordpress.py
@@ -7,6 +7,7 @@ import logging
 from tcia_utils.utils import searchDf
 from tcia_utils.utils import remove_html_tags
 from tcia_utils.utils import copy_df_cols
+from tcia_utils.utils import get_proxy
 
 _log = logging.getLogger(__name__)
 logging.basicConfig(
@@ -58,7 +59,7 @@ def getQuery(endpoint, per_page, format="", file_name=None, fields=None, ids=Non
     
     # Make a GET request to the API endpoint with the parameters
     _log.info('Requesting %s', url)
-    response = requests.get(url, params=params)
+    response = requests.get(url, params=params, proxies=get_proxy())
     
     # Check if the request was successful
     if response.status_code == 200:
@@ -69,7 +70,7 @@ def getQuery(endpoint, per_page, format="", file_name=None, fields=None, ids=Non
         while 'next' in response.links.keys():
             next_url = response.links['next']['url']
             _log.info('Requesting %s', next_url)
-            response = requests.get(next_url)
+            response = requests.get(next_url, proxies=get_proxy())
             if response.status_code == 200:
                 data.extend(response.json())
             else:
@@ -201,7 +202,8 @@ def update_download_file_column(data, max_workers=10):
         try:
             response = requests.get(
                 f'https://cancerimagingarchive.net/api/wp/v2/media/{media_id}',
-                timeout=10
+                timeout=10,
+                proxies=get_proxy()
             )
             if response.status_code == 200:
                 media_data = response.json()


### PR DESCRIPTION
This change introduces global proxy support to the `tcia_utils` library. Users can now set a proxy configuration once using `tcia_utils.utils.set_proxy()`, and it will be automatically applied to all subsequent external API requests made by the library's various modules (`nbia`, `wordpress`, `datacite`, `pathdb`, and `idc`). This is implemented by passing the `proxies` parameter to all `requests.get()` and `requests.post()` calls within the library. If no proxy is set, the library continues to use its default behavior.

---
*PR created automatically by Jules for task [11587085126568247714](https://jules.google.com/task/11587085126568247714) started by @kirbyju*