### PR TITLE
Fix idc.downloadSeries directory structure and sync logic

### DIFF
--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -426,18 +426,22 @@ def _processManifest(manifest_path: str) -> Union[List[str], str]:
 
 def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
                    number: int = 0,
-                   path: str = "idcDownload",
+                   path: str = "tciaDownload",
                    input_type: str = "",
                    format: str = "",
+                   template: str = "flat",
+                   use_sync: bool = True,
                    max_workers: int = 10):
     """
     Ingests a set of seriesUids and downloads them.
     By default, series_data expects JSON containing "SeriesInstanceUID" elements.
     Set number = n to download the first n series if you don't want the full dataset.
-    Saves to idcDownload folder in current directory if no path is specified.
+    Saves to tciaDownload folder in current directory if no path is specified.
     Set input_type = "list" to pass a list of Series UIDs instead of JSON.
     Set input_type = "df" to pass a dataframe that contains a "SeriesInstanceUID" column.
     Set input_type = "manifest" to pass the path of a TCIA, CSV/TSV or s5cmd manifest file.
+    Set template = "flat" (default), "nested", or a custom idc-index dirTemplate.
+    Set use_sync = True (default) to use s5cmd sync for efficient downloading.
     """
     client = get_client()
     series_uids = []
@@ -456,10 +460,18 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
     else:
         series_uids = [item['SeriesInstanceUID'] for item in series_data]
 
+    # Map template to dirTemplate
+    if template == "flat":
+        dir_template = "%SeriesInstanceUID"
+    elif template == "nested":
+        dir_template = "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID"
+    else:
+        dir_template = template
+
     # Ensure the root directory exists
     try:
         if not os.path.exists(path):
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
             _log.info(f"Directory '{path}' created successfully.")
         else:
             _log.info(f"Directory '{path}' already exists.")
@@ -468,19 +480,48 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
         return None
 
     # Identify series to download vs. already existing
-    existing_files = set(os.listdir(path))
     uids_to_download = []
     previously_downloaded_uids = []
 
     if not s5cmd_manifest:
-        for seriesUID in series_uids:
-            if seriesUID not in existing_files:
-                uids_to_download.append(seriesUID)
-            else:
-                _log.warning(f"Series {seriesUID} already downloaded.")
-                previously_downloaded_uids.append(seriesUID)
+        # For non-flat templates, we need metadata to determine the directory paths
+        if dir_template != "%SeriesInstanceUID":
+            _log.info("Fetching metadata to identify existing series...")
+            df_metadata = getSeriesList(series_uids, format="df")
+            if df_metadata.empty:
+                _log.warning("No metadata found for provided series UIDs.")
+                return None
 
-        # Apply 'number' limit if specified
+            # Re-map columns back to IDC internal names for path formatting
+            REVERSE_MAPPING = {v: k for k, v in COLUMN_MAPPING.items()}
+            df_metadata = df_metadata.rename(columns=REVERSE_MAPPING)
+
+            for _, row in df_metadata.iterrows():
+                seriesUID = row['SeriesInstanceUID']
+                # Construct path relative to 'path' using dir_template
+                rel_path = dir_template
+                for key in ['PatientID', 'collection_id', 'Modality', 'StudyInstanceUID', 'SeriesInstanceUID']:
+                    placeholder = f"%{key}"
+                    if placeholder in rel_path:
+                        rel_path = rel_path.replace(placeholder, str(row.get(key, "")))
+
+                full_series_path = os.path.join(path, rel_path)
+                if os.path.exists(full_series_path) and os.listdir(full_series_path):
+                    _log.warning(f"Series {seriesUID} already downloaded at {rel_path}.")
+                    previously_downloaded_uids.append(seriesUID)
+                else:
+                    uids_to_download.append(seriesUID)
+        else:
+            # Flat template: directory names are just SeriesInstanceUID
+            for seriesUID in series_uids:
+                full_series_path = os.path.join(path, seriesUID)
+                if os.path.exists(full_series_path) and os.listdir(full_series_path):
+                    _log.warning(f"Series {seriesUID} already downloaded.")
+                    previously_downloaded_uids.append(seriesUID)
+                else:
+                    uids_to_download.append(seriesUID)
+
+        # Apply 'number' limit to NEW series if specified
         if number > 0:
             uids_to_download = uids_to_download[:number]
 
@@ -489,10 +530,16 @@ def downloadSeries(series_data: Union[str, pd.DataFrame, List[str]],
 
     if s5cmd_manifest:
         _log.info(f"Downloading from s5cmd manifest {s5cmd_manifest} to {path}...")
-        client.download_from_manifest(manifestFile=s5cmd_manifest, downloadDir=path)
+        client.download_from_manifest(manifestFile=s5cmd_manifest,
+                                     downloadDir=path,
+                                     dirTemplate=dir_template,
+                                     use_s5cmd_sync=use_sync)
     elif uids_to_download:
         _log.info(f"Downloading {len(uids_to_download)} series to {path}...")
-        client.download_dicom_series(seriesInstanceUID=uids_to_download, downloadDir=path)
+        client.download_dicom_series(seriesInstanceUID=uids_to_download,
+                                    downloadDir=path,
+                                    dirTemplate=dir_template,
+                                    use_s5cmd_sync=use_sync)
     elif not previously_downloaded_uids:
         _log.warning("No data found to download.")
         return None

--- a/tests/test_idc_download_fix.py
+++ b/tests/test_idc_download_fix.py
@@ -1,0 +1,120 @@
+
+import unittest
+from unittest.mock import MagicMock, patch
+import pandas as pd
+import os
+import shutil
+from tcia_utils import idc
+
+class TestIDCDownload(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = "test_tcia_download"
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+        os.makedirs(self.test_dir)
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    @patch("tcia_utils.idc.get_client")
+    @patch("tcia_utils.idc.getSeriesList")
+    def test_downloadSeries_flat_already_exists(self, mock_getSeriesList, mock_get_client):
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        series_uids = ["uid1", "uid2"]
+        # Create directory for uid1 to simulate already downloaded
+        os.makedirs(os.path.join(self.test_dir, "uid1"))
+        with open(os.path.join(self.test_dir, "uid1", "test.dcm"), "w") as f:
+            f.write("dummy")
+
+        idc.downloadSeries(series_uids, path=self.test_dir, input_type="list", template="flat")
+
+        # Should only attempt to download uid2
+        mock_client.download_dicom_series.assert_called_once()
+        args, kwargs = mock_client.download_dicom_series.call_args
+        self.assertEqual(kwargs['seriesInstanceUID'], ["uid2"])
+        self.assertEqual(kwargs['dirTemplate'], "%SeriesInstanceUID")
+        self.assertEqual(kwargs['use_s5cmd_sync'], True)
+
+    @patch("tcia_utils.idc.get_client")
+    @patch("tcia_utils.idc.getSeriesList")
+    def test_downloadSeries_nested_already_exists(self, mock_getSeriesList, mock_get_client):
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        series_uids = ["uid1", "uid2"]
+
+        # Mock metadata for both series
+        mock_metadata = pd.DataFrame([
+            {
+                "SeriesInstanceUID": "uid1",
+                "Collection": "coll1",
+                "PatientID": "pat1",
+                "StudyInstanceUID": "study1",
+                "Modality": "CT"
+            },
+            {
+                "SeriesInstanceUID": "uid2",
+                "Collection": "coll2",
+                "PatientID": "pat2",
+                "StudyInstanceUID": "study2",
+                "Modality": "MR"
+            }
+        ])
+        mock_getSeriesList.return_value = mock_metadata
+
+        # Create nested directory for uid1
+        # Default nested: %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID
+        uid1_path = os.path.join(self.test_dir, "coll1", "pat1", "study1", "CT_uid1")
+        os.makedirs(uid1_path)
+        with open(os.path.join(uid1_path, "test.dcm"), "w") as f:
+            f.write("dummy")
+
+        idc.downloadSeries(series_uids, path=self.test_dir, input_type="list", template="nested")
+
+        # Should only attempt to download uid2
+        mock_client.download_dicom_series.assert_called_once()
+        args, kwargs = mock_client.download_dicom_series.call_args
+        self.assertEqual(kwargs['seriesInstanceUID'], ["uid2"])
+        self.assertEqual(kwargs['dirTemplate'], "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID")
+
+    @patch("tcia_utils.idc.get_client")
+    @patch("tcia_utils.idc.getSeriesList")
+    def test_downloadSeries_number_limit(self, mock_getSeriesList, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        series_uids = ["uid1", "uid2", "uid3"]
+        # uid1 exists
+        os.makedirs(os.path.join(self.test_dir, "uid1"))
+        with open(os.path.join(self.test_dir, "uid1", "test.dcm"), "w") as f:
+            f.write("dummy")
+
+        # Limit to 1 NEW series
+        idc.downloadSeries(series_uids, path=self.test_dir, input_type="list", number=1, template="flat")
+
+        mock_client.download_dicom_series.assert_called_once()
+        args, kwargs = mock_client.download_dicom_series.call_args
+        self.assertEqual(kwargs['seriesInstanceUID'], ["uid2"])
+
+    @patch("tcia_utils.idc.get_client")
+    @patch("tcia_utils.idc._processManifest")
+    def test_downloadSeries_s5cmd_manifest(self, mock_processManifest, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_processManifest.return_value = "test.s5cmd"
+
+        idc.downloadSeries("test.s5cmd", path=self.test_dir, input_type="manifest", template="nested")
+
+        mock_client.download_from_manifest.assert_called_once()
+        args, kwargs = mock_client.download_from_manifest.call_args
+        self.assertEqual(kwargs['manifestFile'], "test.s5cmd")
+        self.assertEqual(kwargs['dirTemplate'], "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID")
+        self.assertEqual(kwargs['use_s5cmd_sync'], True)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `downloadSeries` function in `idc.py` was previously unable to correctly identify existing series when using the nested directory structure default to `idc-index`. This PR fixes this by:
1. Adding a `template` parameter to `downloadSeries`, supporting 'flat' (UID-only subdirectories), 'nested' (collection/patient/study/series hierarchy), or custom `idc-index` templates.
2. Refactoring existing series detection to use metadata-derived paths, ensuring accuracy across all template types.
3. Leveraging the `use_s5cmd_sync` feature of `idc-index` to optimize the download process.
4. Correcting the `number` parameter logic to limit the number of *new* series downloaded.
5. Updating the default download directory to `tciaDownload` to match the behavior of the `nbia` module.
6. Adding a new test suite `tests/test_idc_download_fix.py` to verify these changes.

---
*PR created automatically by Jules for task [16593116608678164587](https://jules.google.com/task/16593116608678164587) started by @kirbyju*