### PR TITLE
Fix binary size labels and reporting column in idc.py

### DIFF
--- a/src/tcia_utils/idc.py
+++ b/src/tcia_utils/idc.py
@@ -718,7 +718,8 @@ def reportDataSummary(series_data, input_type="", report_type = "", format=""):
         'FileSizeMiB': 'File Size MiB'
     }, inplace=True)
 
-    summary['Disk Space'] = (summary['File Size MiB'] * 1024 * 1024).apply(format_disk_space_binary)
+    summary['Formatted File Size'] = (summary['File Size MiB'] * 1024 * 1024).apply(format_disk_space_binary)
+    summary['File Size MiB'] = summary['File Size MiB'].round(2)
 
     if format == 'chart':
         for metric in ['Subjects', 'Studies', 'Series', 'Images']:

--- a/src/tcia_utils/utils.py
+++ b/src/tcia_utils/utils.py
@@ -128,15 +128,15 @@ def format_disk_space_binary(size_in_bytes):
     I.e. Mebibytes (MiB) reported in Windows.
     """
     if size_in_bytes < 1024 ** 2:
-        return f'{size_in_bytes / 1024:.2f} KB'
+        return f'{size_in_bytes / 1024:.2f} KiB'
     elif size_in_bytes < 1024 ** 3:
-        return f'{size_in_bytes / (1024 ** 2):.2f} MB'
+        return f'{size_in_bytes / (1024 ** 2):.2f} MiB'
     elif size_in_bytes < 1024 ** 4:
-        return f'{size_in_bytes / (1024 ** 3):.2f} GB'
+        return f'{size_in_bytes / (1024 ** 3):.2f} GiB'
     elif size_in_bytes < 1024 ** 5:
-        return f'{size_in_bytes / (1024 ** 4):.2f} TB'
+        return f'{size_in_bytes / (1024 ** 4):.2f} TiB'
     else:
-        return f'{size_in_bytes / (1024 ** 5):.2f} PB'
+        return f'{size_in_bytes / (1024 ** 5):.2f} PiB'
         
 
 def format_disk_space(size_in_bytes):


### PR DESCRIPTION
This change addresses the user's request to fix the binary size labels in `idc.py` and update the reporting column header.

Specifically:
1.  **IEC Labels:** Modified `format_disk_space_binary` in `src/tcia_utils/utils.py` to use standard IEC labels (KiB, MiB, GiB, etc.) instead of decimal labels (KB, MB, GB, etc.) while keeping the base-1024 math.
2.  **Column Rename:** Updated `reportDataSummary` in `src/tcia_utils/idc.py` to rename the "Disk Space" column to "Formatted File Size".
3.  **Rounding:** Added rounding to 2 decimal places for the "File Size MiB" column in `src/tcia_utils/idc.py` summaries.
4.  **Consistency:** Ensured `nbia.py` remains unaffected as requested, as it uses `format_disk_space` (base-1000).

Verification:
- Ran a custom script to confirm the new column name and labels in `reportCollectionSummary` output.
- Ran existing unit tests in `tests/test_idc.py` to ensure no regressions. All 16 tests passed.

---
*PR created automatically by Jules for task [5487107883143516621](https://jules.google.com/task/5487107883143516621) started by @kirbyju*